### PR TITLE
Feat: added config save support in package manager

### DIFF
--- a/src/github.com/Narasimha1997/pavlos/core/container.go
+++ b/src/github.com/Narasimha1997/pavlos/core/container.go
@@ -13,7 +13,10 @@ import (
 var home string = os.Getenv("HOME")
 
 //DefaultRootFsAbsPath : Default rootfs for kontainer, change this according to your needs
-var DefaultRootFsAbsPath string = filepath.Join(home, ".rootfs")
+var DefaultRootFsAbsPath string = filepath.Join(home, ".rootfs/images")
+
+//DefaultRootFsConfigPath : Default rootfs configs path
+var DefaultRootFsConfigPath string = filepath.Join(home, ".rootfs/configs")
 
 //IsolationOpts : Linux syscall isolation options
 type IsolationOpts struct {
@@ -134,7 +137,18 @@ func ProduceUnsupportedWarnings(config *ContainerOpts) {
 }
 
 //LoadConfigFromJSON : Configuration loader
-func LoadConfigFromJSON(jsonFile string) ContainerOpts {
+func LoadConfigFromJSON(jsonFile string, fromFile bool) ContainerOpts {
+
+	if !fromFile {
+		jsonFile = filepath.Join(DefaultRootFsConfigPath, jsonFile)
+	}
+
+	_, err := os.Stat(jsonFile)
+	if os.IsNotExist(err) {
+		fmt.Printf("Configuration file %s does not exist.\n", jsonFile)
+		os.Exit(0)
+	}
+
 	jsonData, err := ioutil.ReadFile(jsonFile)
 	catchError(err)
 	options := ContainerOpts{}

--- a/src/github.com/Narasimha1997/pavlos/core/runtime.go
+++ b/src/github.com/Narasimha1997/pavlos/core/runtime.go
@@ -100,7 +100,7 @@ func jsonToConfigs(jsonData string, containerConfig *ContainerOpts) {
 }
 
 //CreateContainer : Main function that creates a container
-func CreateContainer(configFile string) {
+func CreateContainer(configFile string, fromFile bool) {
 	_, err := os.Stat(configFile)
 	catchError(err)
 
@@ -109,7 +109,7 @@ func CreateContainer(configFile string) {
 		os.Exit(0)
 	}
 
-	options := LoadConfigFromJSON(configFile)
+	options := LoadConfigFromJSON(configFile, fromFile)
 
 	konArgs := append([]string{makeConfigsPassthrough(&options)}, options.RuntimeArgs...)
 	executorHandle := MakeContainerRuntime(&options, konArgs)

--- a/src/github.com/Narasimha1997/pavlos/main.go
+++ b/src/github.com/Narasimha1997/pavlos/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	switch argument {
 	case "run":
-		core.CreateContainer(os.Args[2])
+		core.CreateContainer(os.Args[2], false)
 	case "container":
 		core.ContainerRuntime()
 	default:


### PR DESCRIPTION
Modified : 
   1. Package manager : 
       a. Support for saving config files.
       b. List, Delete and edit config files.
       c. Link  config files with Rootfs images
   2. Pavlos : 
        a. Ability to fetch and run configs directly from Registry                              
